### PR TITLE
Append index.html if the s3 object key ends in slash

### DIFF
--- a/lib/staticizer/crawler.rb
+++ b/lib/staticizer/crawler.rb
@@ -158,6 +158,7 @@ module Staticizer
     def save_page_to_aws(response, uri)
       key = uri.path
       key += "?#{uri.query}" if uri.query
+      key = key.gsub(%r{/$},"/index.html")
       key = key.gsub(%r{^/},"")
       key = "index.html" if key == ""
       # Upload this file directly to AWS::S3


### PR DESCRIPTION
I was getting an issue where staticizer was trying to write to a key like `products/` which was inaccessible through the web. This patch makes it so that any path which ends in slash gets index.html appended to it. `products/` would become `products/index.html`
